### PR TITLE
chore: update action to new repository location

### DIFF
--- a/.github/workflows/secrets.yml
+++ b/.github/workflows/secrets.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Sync secrets for Docker repos
-        uses: google/secrets-sync-action@31492f4828d1a2d51d4e1d2404710247b7cabb47 # v1.7.1
+        uses: jpoehnelt/secrets-sync-action@31492f4828d1a2d51d4e1d2404710247b7cabb47 # v1.7.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           secrets: |
@@ -29,7 +29,7 @@ jobs:
           DOCKER_TOKEN: ${{ secrets.DOCKER_TOKEN }}
 
       - name: Sync crates.io token
-        uses: google/secrets-sync-action@31492f4828d1a2d51d4e1d2404710247b7cabb47 # v1.7.1
+        uses: jpoehnelt/secrets-sync-action@31492f4828d1a2d51d4e1d2404710247b7cabb47 # v1.7.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           secrets: |
@@ -55,7 +55,7 @@ jobs:
           CRATESIO_TOKEN: ${{ secrets.CRATESIO_TOKEN }}
 
       - name: Sync GitHub tokens
-        uses: google/secrets-sync-action@31492f4828d1a2d51d4e1d2404710247b7cabb47 # v1.7.1
+        uses: jpoehnelt/secrets-sync-action@31492f4828d1a2d51d4e1d2404710247b7cabb47 # v1.7.1
         with:
           github_token: ${{ secrets.GH_TOKEN }}
           secrets: |


### PR DESCRIPTION
This is a PR to update the action to the new repository location from https://github.com/google/secrets-sync-action to https://github.com/jpoehnelt/secrets-sync-action. Note that GitHub does redirect the old repository to the new one, so this is more housekeeping than anything else.